### PR TITLE
New patch release of Golang: v1.21.2

### DIFF
--- a/projects/golang/go/1.21/README.md
+++ b/projects/golang/go/1.21/README.md
@@ -1,17 +1,17 @@
 # EKS Golang 1.21
 
-Current Release: `4`
+Current Release: `5`
 
-Tracking Tag: `go1.21.3`
+Tracking Tag: `go1.21.2`
 
 ### Artifacts:  
 |Arch|Artifact|sha|
 |:---:|:---:|:---:|
-|noarch|[golang-src-1.21.3-4.amzn2.eks.noarch.rpm](https://distro.eks.amazonaws.com/golang-go1.21.3/releases/4/x86_64/RPMS/noarch/golang-src-1.21.3-4.amzn2.eks.noarch.rpm)|[golang-src-1.21.3-4.amzn2.eks.noarch.rpm.sha256](https://distro.eks.amazonaws.com/golang-go1.21.3/releases/4/x86_64/RPMS/noarch/golang-src-1.21.3-4.amzn2.eks.noarch.rpm.sha256)|
-|x86_64|[golang-1.21.3-4.amzn2.eks.x86_64.rpm](https://distro.eks.amazonaws.com/golang-go1.21.3/releases/4/x86_64/RPMS/x86_64/golang-1.21.3-4.amzn2.eks.x86_64.rpm)|[golang-1.21.3-4.amzn2.eks.x86_64.rpm.sha256](https://distro.eks.amazonaws.com/golang-go1.21.3/releases/4/x86_64/RPMS/x86_64/golang-1.21.3-4.amzn2.eks.x86_64.rpm.sha256)|
-|aarch64|[golang-1.21.3-4.amzn2.eks.aarch64.rpm](https://distro.eks.amazonaws.com/golang-go1.21.3/releases/4/aarch64/RPMS/aarch64/golang-1.21.3-4.amzn2.eks.aarch64.rpm)|[golang-1.21.3-4.amzn2.eks.aarch64.rpm.sha256](https://distro.eks.amazonaws.com/golang-go1.21.3/releases/4/aarch64/RPMS/aarch64/golang-1.21.3-4.amzn2.eks.aarch64.rpm.sha256)|
-|arm64|[go1.21.3.linux-arm64.tar.gz](https://distro.eks.amazonaws.com/golang-go1.21.3/releases/4/archives/linux/arm64/go1.21.3.linux-arm64.tar.gz)|[go1.21.3.linux-arm64.tar.gz.sha256](https://distro.eks.amazonaws.com/golang-go1.21.3/releases/4/archives/linux/arm64/go1.21.3.linux-arm64.tar.gz.sha256)|
-|amd64|[go1.21.3.linux-amd64.tar.gz](https://distro.eks.amazonaws.com/golang-go1.21.3/releases/4/archives/linux/amd64/go1.21.3.linux-amd64.tar.gz)|[go1.21.3.linux-amd64.tar.gz.sha256](https://distro.eks.amazonaws.com/golang-go1.21.3/releases/4/archives/linux/amd64/go1.21.3.linux-amd64.tar.gz.sha256)|
+|noarch|[golang-1.21.2-5.amzn2.eks.noarch.rpm](https://distro.eks.amazonaws.com/golang-go1.21.2/release/5/x86_64/RPMS/noarch/golang-1.21.2-5.amzn2.eks.noarch.rpm)|[golang-1.21.2-5.amzn2.eks.noarch.rpm.sha256](https://distro.eks.amazonaws.com/golang-go1.21.2/release/5/x86_64/RPMS/noarch/golang-1.21.2-5.amzn2.eks.noarch.rpm.sha256)|
+|x86_64|[golang-1.21.2-5.amzn2.eks.x86_64.rpm](https://distro.eks.amazonaws.com/golang-go1.21.2/release/5/x86_64/RPMS/x86_64/golang-1.21.2-5.amzn2.eks.x86_64.rpm)|[golang-1.21.2-5.amzn2.eks.x86_64.rpm.sha256](https://distro.eks.amazonaws.com/golang-go1.21.2/release/5/x86_64/RPMS/x86_64/golang-1.21.2-5.amzn2.eks.x86_64.rpm.sha256)|
+|aarch64|[golang-1.21.2-5.amzn2.eks.aarch64.rpm](https://distro.eks.amazonaws.com/golang-go1.21.2/release/5/aarch64/RPMS/aarch64/golang-1.21.2-5.amzn2.eks.aarch64.rpm)|[golang-1.21.2-5.amzn2.eks.aarch64.rpm.sha256](https://distro.eks.amazonaws.com/golang-go1.21.2/release/5/aarch64/RPMS/aarch64/golang-1.21.2-5.amzn2.eks.aarch64.rpm.sha256)|
+|arm64|[go1.21.2.linux-arm64.tar.gz](https://distro.eks.amazonaws.com/golang-go1.21.2/release/5/archives/linux/arm64/go1.21.2.linux-arm64.tar.gz)|[go1.21.2.linux-arm64.tar.gz.sha256](https://distro.eks.amazonaws.com/golang-go1.21.2/release/5/archives/linux/arm64/go1.21.2.linux-arm64.tar.gz.sha256)|
+|amd64|[go1.21.2.linux-amd64.tar.gz](https://distro.eks.amazonaws.com/golang-go1.21.2/release/5/archives/linux/amd64/go1.21.2.linux-amd64.tar.gz)|[go1.21.2.linux-amd64.tar.gz.sha256](https://distro.eks.amazonaws.com/golang-go1.21.2/release/5/archives/linux/amd64/go1.21.2.linux-amd64.tar.gz.sha256)|
 
 
 ### ARM64 Builds


### PR DESCRIPTION
Update EKS Go Patch Version: v1.21.2-5
SPEC FILE STILL NEEDS THE '%changelog' UPDATED
PLEASE UPDATE WITH THE FOLLOWING FORMAT
```
* Wed Sep 06 2023 Cameron Rozean <rcrozean@amazon.com> - 1.20.8-1
- Bump tracking patch version to 1.20.8 from 1.20.7
```